### PR TITLE
Create constants based on all locale data

### DIFF
--- a/cmd/make_resources/process_cldr.go
+++ b/cmd/make_resources/process_cldr.go
@@ -165,9 +165,7 @@ func processNumbers(ldmlNumbers *cldr.Numbers) (number i18n.Number) {
 			}
 		}
 	}
-	//if len(ldmlNumbers.CurrencyFormats) > 0 && len(ldmlNumbers.CurrencyFormats[0].CurrencyFormatLength) > 0 {
-	//	number.Formats.Currency = ldmlNumbers.CurrencyFormats[0].CurrencyFormatLength[0].CurrencyFormat[0].Pattern[0].Data()
-	//}
+
 	if len(ldmlNumbers.PercentFormats) > 0 && len(ldmlNumbers.PercentFormats[0].PercentFormatLength) > 0 {
 		number.Formats.Percent = ldmlNumbers.PercentFormats[0].PercentFormatLength[0].PercentFormat[0].Pattern[0].Data()
 	}

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,11 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/razor-1/cldr v0.1.9/go.mod h1:YVh/jvrQKLJMOGUayvKMj1yjN6tN3GLzv6WHIe+UXeg=
+github.com/razor-1/cldr v0.1.10/go.mod h1:9ok2lxmDGp3spDcwysih1tD6G4AEn3N79vW6OBcHsGg=
 github.com/razor-1/cldr/resources v0.1.10 h1:abNZA0k3ae+1hNWs8dZKDNiWIFmCjCVmoiGSCu+Y6lI=
 github.com/razor-1/cldr/resources v0.1.10/go.mod h1:R9wk1owqJahFJIdvm3C5xSrHw4/+6t5SYZDBGLgMsUs=
+github.com/razor-1/cldr/resources v0.1.11 h1:sSt4/cpbqClsNhT83bYMlOhsQOW+7oOqTEJRlQMjjEU=
+github.com/razor-1/cldr/resources v0.1.11/go.mod h1:Hq9tz3hZWqDDCd9x0xNaeaeB6dln9V02XZvh4Qrb9fo=
 github.com/razor-1/cldr/resources/currency v0.1.0/go.mod h1:2w6OlImUjqkHrExnG6V5/UltqFdE6oQ0ZmEBZvgbfjw=
 github.com/razor-1/cldr/resources/currency v0.1.1 h1:0JaESp1ztMUUwNKgsVKEmo46wdzfm6sfVbwJmIDkX1Y=
 github.com/razor-1/cldr/resources/currency v0.1.1/go.mod h1:2w6OlImUjqkHrExnG6V5/UltqFdE6oQ0ZmEBZvgbfjw=

--- a/resources/currency/go.mod
+++ b/resources/currency/go.mod
@@ -1,1 +1,3 @@
 module "github.com/razor-1/cldr/resources/currency"
+
+go 1.15

--- a/resources/go.mod
+++ b/resources/go.mod
@@ -1,6 +1,6 @@
 module github.com/razor-1/cldr/resources
 
-go 1.14
+go 1.15
 
 require (
 	github.com/razor-1/cldr v0.1.10

--- a/resources/language/go.mod
+++ b/resources/language/go.mod
@@ -1,3 +1,3 @@
 module github.com/razor-1/cldr/resources/language
 
-go 1.14
+go 1.15

--- a/resources/language/language.go
+++ b/resources/language/language.go
@@ -44,6 +44,7 @@ const (
 	AWA     = "awa"
 	AY      = "ay"
 	AZ      = "az"
+	AZ_ARAB = "az_Arab"
 	BA      = "ba"
 	BAL     = "bal"
 	BAN     = "ban"

--- a/resources/territory/go.mod
+++ b/resources/territory/go.mod
@@ -1,3 +1,3 @@
 module github.com/razor-1/cldr/resources/territory
 
-go 1.14
+go 1.15


### PR DESCRIPTION
We used to pick one locale, `en`, and create the language, currency and territory constants from it. Now we aggregate all of this across all locales to ensure we get everything.